### PR TITLE
Retry instead of restart when MQTT is not configured

### DIFF
--- a/dsmr_mqtt/services/broker.py
+++ b/dsmr_mqtt/services/broker.py
@@ -18,9 +18,9 @@ def initialize():
     broker_settings = MQTTBrokerSettings.get_solo()
 
     if not broker_settings.hostname:
-        logger.warning('MQTT | No hostname found in settings, restarting in a minute...')
+        logger.warning('MQTT | No hostname found in settings, retrying in a minute...')
         time.sleep(60)
-        raise StopInfiniteRun()
+        return initialize()
 
     mqtt_client = paho.Client(client_id=broker_settings.client_id)
     mqtt_client.on_connect = on_connect


### PR DESCRIPTION
Gets rid of a lot of logs each minute. Fixes #543.