### PR TITLE
Add basic netatmo outside temperature support

### DIFF
--- a/dsmr_weather/tests/test_services.py
+++ b/dsmr_weather/tests/test_services.py
@@ -19,11 +19,11 @@ class TestDsmrWeatherServices(TestCase):
         self.schedule_process = ScheduledProcess.objects.get(module=settings.DSMRREADER_MODULE_WEATHER_UPDATE)
         self.schedule_process.update(active=True, planned=timezone.make_aware(timezone.datetime(2017, 1, 1)))
 
-    @mock.patch('dsmr_weather.services.get_temperature_from_api')
+    @mock.patch('dsmr_weather.services.get_temperature_from_buienradar')
     @mock.patch('django.utils.timezone.now')
-    def test_exception_handling(self, now_mock, get_temperature_from_api_mock):
+    def test_exception_handling(self, now_mock, get_temperature_from_buienradar_mock):
         now_mock.return_value = timezone.make_aware(timezone.datetime(2017, 1, 1))
-        get_temperature_from_api_mock.side_effect = AssertionError('TEST')  # Simulate any exception.
+        get_temperature_from_buienradar_mock.side_effect = AssertionError('TEST')  # Simulate any exception.
 
         dsmr_weather.services.run(self.schedule_process)
 
@@ -63,7 +63,7 @@ class TestDsmrWeatherServices(TestCase):
         requests_mock.side_effect = IOError('Failed to connect')  # Any error is fine.
 
         with self.assertRaises(AssertionError):
-            dsmr_weather.services.get_temperature_from_api()
+            dsmr_weather.services.get_temperature_from_buienradar()
 
     @mock.patch('requests.get')
     @mock.patch('django.utils.timezone.now')
@@ -74,7 +74,7 @@ class TestDsmrWeatherServices(TestCase):
         requests_mock.return_value = response_mock
 
         with self.assertRaises(AssertionError):
-            dsmr_weather.services.get_temperature_from_api()
+            dsmr_weather.services.get_temperature_from_buienradar()
 
     @mock.patch('requests.get')
     @mock.patch('django.utils.timezone.now')
@@ -93,4 +93,4 @@ class TestDsmrWeatherServices(TestCase):
         requests_mock.return_value = response_mock
 
         with self.assertRaises(AssertionError):
-            dsmr_weather.services.get_temperature_from_api()
+            dsmr_weather.services.get_temperature_from_buienradar()

--- a/dsmrreader/provisioning/requirements/base.txt
+++ b/dsmrreader/provisioning/requirements/base.txt
@@ -21,3 +21,4 @@ pytz==2020.1
 pyyaml==5.3.1
 requests==2.24.0
 urllib3==1.25.10
+netatmo==1.0.3


### PR DESCRIPTION
Dit is een snelle hack om ipv Buienradar de Netatmo API te gebruiken. Ik ken DSMR / Django niet goed genoeg om dit netjes te integreren. 

Todo:
1. Keuze maken in de settings tussen Buienradar en Netatmo
1. Credentials voor Netatmo via de webgui kunnen invoeren

Het opslaan van de credentials gebeurt door de Netatmo python module in ~/.netatmorc via de volgende code (eenmalig nodig):
```
ws = netatmo.WeatherStation( {
        'client_id': '1234567890abcdef12345678',
        'client_secret': 'ABCdefg123456hijklmn7890pqrs',
        'username': 'user@mail',
        'password': 'password',
        'device': '70:ee:50:XX:XX:XX' } )
 ws.save_credentials()
```
Hierbij is de client_id en client_secret te verkrijgen via http://dev.netatmo.com/apps/createanapp en het device niet verplicht (alleen relevant als je meer dan 1 Netatmo stations hebt en je niet de eerste in je account wil gebruiken).