### PR TITLE
Add support for DSMR version 2 on dsmr_datalogger_api_client

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -573,6 +573,7 @@ Then add the following contents to ``/home/dsmr/.env``::
     DATALOGGER_INPUT_METHOD=serial
     DATALOGGER_SERIAL_PORT=/dev/ttyUSB0
     DATALOGGER_SERIAL_BAUDRATE=115200
+    DATALOGGER_DSMR_VERSION=4 # Or 2, depending on your meter model. 
 
 When using a different port or baud rate, change the ``DATALOGGER_SERIAL_PORT`` / ``DATALOGGER_SERIAL_BAUDRATE`` values accordingly.
 

--- a/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
+++ b/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
@@ -122,11 +122,11 @@ def main():  # noqa: C901
     )
 
     if DATALOGGER_INPUT_METHOD == 'serial':
-        bytesize=serial.EIGHTBITS
-        parity=serial.PARITY_NONE
+        bytesize = serial.EIGHTBITS
+        parity = serial.PARITY_NONE
         if decouple.config('DATALOGGER_DSMR_VERSION') == 2:
-            bytesize=serial.SEVENBITS
-            parity=serial.PARITY_EVEN
+            bytesize = serial.SEVENBITS
+            parity = serial.PARITY_EVEN
         serial_kwargs.update(dict(
             url_or_port=decouple.config('DATALOGGER_SERIAL_PORT'),
             baudrate=decouple.config('DATALOGGER_SERIAL_BAUDRATE', cast=int),

--- a/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
+++ b/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
@@ -122,11 +122,16 @@ def main():  # noqa: C901
     )
 
     if DATALOGGER_INPUT_METHOD == 'serial':
+        bytesize=serial.EIGHTBITS
+        parity=serial.PARITY_NONE
+        if decouple.config('DATALOGGER_DSMR_VERSION') == 2:
+            bytesize=serial.SEVENBITS
+            parity=serial.PARITY_EVEN
         serial_kwargs.update(dict(
             url_or_port=decouple.config('DATALOGGER_SERIAL_PORT'),
             baudrate=decouple.config('DATALOGGER_SERIAL_BAUDRATE', cast=int),
-            bytesize=serial.EIGHTBITS,
-            parity=serial.PARITY_NONE,
+            bytesize=bytesize,
+            parity=parity,
             stopbits=serial.STOPBITS_ONE,
             xonxoff=1,
             rtscts=0,

--- a/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
+++ b/dsmr_datalogger/scripts/dsmr_datalogger_api_client.py
@@ -124,7 +124,7 @@ def main():  # noqa: C901
     if DATALOGGER_INPUT_METHOD == 'serial':
         bytesize = serial.EIGHTBITS
         parity = serial.PARITY_NONE
-        if decouple.config('DATALOGGER_DSMR_VERSION') == 2:
+        if decouple.config('DATALOGGER_DSMR_VERSION', cast=int) == 2:
             bytesize = serial.SEVENBITS
             parity = serial.PARITY_EVEN
         serial_kwargs.update(dict(

--- a/dsmr_datalogger/tests/script/test_datalogger_api_client.py
+++ b/dsmr_datalogger/tests/script/test_datalogger_api_client.py
@@ -23,6 +23,7 @@ import dsmr_datalogger.scripts.dsmr_datalogger_api_client
     DATALOGGER_TIMEOUT='0.123',
     DATALOGGER_SLEEP='0.1',
     DATALOGGER_MIN_SLEEP_FOR_RECONNECT='999',
+    DATALOGGER_DSMR_VERSION='4',
 
 ))
 class TestScript(TestCase):

--- a/dsmr_datalogger/tests/script/test_datalogger_api_client.py
+++ b/dsmr_datalogger/tests/script/test_datalogger_api_client.py
@@ -23,6 +23,7 @@ import dsmr_datalogger.scripts.dsmr_datalogger_api_client
     DATALOGGER_TIMEOUT='0.123',
     DATALOGGER_SLEEP='0.1',
     DATALOGGER_MIN_SLEEP_FOR_RECONNECT='999',
+
 ))
 class TestScript(TestCase):
     @mock.patch.dict('os.environ', dict(
@@ -198,6 +199,7 @@ class TestScript(TestCase):
     DATALOGGER_INPUT_METHOD='serial',
     DATALOGGER_SERIAL_PORT='/dev/X',
     DATALOGGER_SERIAL_BAUDRATE='12345',
+    DATALOGGER_DSMR_VERSION='4',
 ))
 class TestScriptErrors(TestCase):
     @mock.patch.dict('os.environ', dict(


### PR DESCRIPTION
When using a remote datalogger [as described here](https://dsmr-reader.readthedocs.io/en/v4/installation.html#remote-datalogger-device) on a version 2 DSMR, you're unable to collect data as both `bytesize` and `parity` are different for these models. I took the liberty of adding an extra configuration parameter in which you can define your DSMR-version: `DATALOGGER_DSMR_VERSION`. In case it is version 2, the `bytesize` and `parity` are set accordingly.