### PR TITLE
Fix docker issue with pg_dump not found

### DIFF
--- a/dsmr_backup/services/backup.py
+++ b/dsmr_backup/services/backup.py
@@ -90,6 +90,7 @@ def create_full(folder: str) -> str:
             db_settings['NAME'],
         ]
         backup_process = subprocess.Popen(command, env={
+            **os.environ,
             'PGPASSWORD': db_settings['PASSWORD']
         },
             stdout=open(backup_file, 'w')  # pragma: no cover
@@ -161,6 +162,7 @@ def create_partial(folder: str, models_to_backup: Iterable) -> str:  # pragma: n
         backup_process = subprocess.Popen(
             command,
             env={
+                **os.environ,
                 'PGPASSWORD': db_settings['PASSWORD']
             },
             stdout=open(backup_file, 'w'),


### PR DESCRIPTION
Fixes the Docker issue discussed before in https://github.com/xirixiz/dsmr-reader-docker/issues/262#issuecomment-1036535965

Background information here: https://stackoverflow.com/questions/65191779/pg-dump-error-in-docker-but-still-executes-successfully