### PR TITLE
Gebruik temperature ipv groundtemperature

### DIFF
--- a/dsmr_weather/services.py
+++ b/dsmr_weather/services.py
@@ -58,7 +58,7 @@ def get_temperature_from_api() -> TemperatureReading:
     if not station_data:
         raise RuntimeError("Selected station info not found: {}".format(station_id))
 
-    temperature = station_data[0]["groundtemperature"]
+    temperature = station_data[0]["temperature"]
     logger.debug("Buienradar: Storing temperature read: %s", temperature)
 
     hour_mark = timezone.now().replace(minute=0, second=0, microsecond=0)


### PR DESCRIPTION
'groundtemperature' is de temperatuur aan de grond. 'temperature' is de temperatuur op 1,5m hoogte. Aangezien de temperatuur aan de grond weinig relatie heeft met gebruik past deze pull dit aan naar die op 1,5m. Voor meer context over temperatuur meting zie ook  https://www.knmi.nl/kennis-en-datacentrum/uitleg/temperatuur