### PR TITLE
Maak data_retention_in_hours nauwkeuriger

### DIFF
--- a/dsmr_datalogger/models/settings.py
+++ b/dsmr_datalogger/models/settings.py
@@ -147,10 +147,10 @@ def _on_datalogger_restart_required_signal(**kwargs):
 class RetentionSettings(ModelUpdateMixin, SingletonModel):
     RETENTION_NONE = None
     RETENTION_WEEK = 7 * 24
-    RETENTION_MONTH = 4 * RETENTION_WEEK
+    RETENTION_MONTH = 24 * 30
     RETENTION_THREE_MONTHS = 3 * RETENTION_MONTH
     RETENTION_HALF_YEAR = 6 * RETENTION_MONTH
-    RETENTION_YEAR = 12 * RETENTION_MONTH
+    RETENTION_YEAR = 24 * 365
     RETENTION_CHOICES = (
         (
             RETENTION_NONE,


### PR DESCRIPTION
I heb mijn retention settings op een jaar staan, maar was verbaasd dat de datagrammen van januari 2023 nu al niet meer allemaal beschikbaar zijn. Dit komt omdat in `RetentionSettings` de uren erg onnauwkeurig zijn gedefinieerd. Deze PR corrigeert dat.

Er is waarschijnlijk ook een migratie script nodig om de oude waardes in `dsmr_datalogger_retentionsettings` aan te passen:
```
672 -> 720
2016 -> 2160
4032 -> 4320
8064 -> 8760
```