### PR TITLE
Set default values to 0 in range_statistics()

### DIFF
--- a/dsmr_stats/services.py
+++ b/dsmr_stats/services.py
@@ -384,6 +384,7 @@ def range_statistics(start: datetime.date, end: datetime.date):
     for decimal_count, fields in rounding.items():
         for current_field in fields:
             if aggregate[current_field] is None:
+                aggregate[current_field] = 0
                 continue
 
             aggregate[current_field] = dsmr_consumption.services.round_decimal(


### PR DESCRIPTION
`range_statistics()` only returns data for full days with the data for the current day being added by `period_totals()` later. This does not work on new years day where there are no full days yet. Setting the default values to 0 fixes this issue.

Fixes #1944
